### PR TITLE
Load common modules via environs.access-om2.nci

### DIFF
--- a/util/make_dir/config.nci
+++ b/util/make_dir/config.nci
@@ -1,5 +1,11 @@
-module purge
-module load intel-fc/17.0.1.132
-module load intel-cc/17.0.1.132
-module load netcdf
-module load openmpi/1.10.2
+if ( -f ../../../../../modules.nci ) then
+    echo "Loading common modules via modules.nci"
+    source ../../../../../modules.nci
+else
+    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    module purge
+    module load intel-fc/17.0.1.132
+    module load intel-cc/17.0.1.132
+    module load netcdf
+    module load openmpi/1.10.2
+endif

--- a/util/make_dir/config.nci
+++ b/util/make_dir/config.nci
@@ -1,6 +1,6 @@
-if ( -f ../../../../../modules.nci ) then
+if [ -f ../../modules.nci ]; then
     echo "Loading common modules via modules.nci"
-    source ../../../../../modules.nci
+    source ../../modules.nci
 else
     echo "WARNING: modules.nci not found. Module versions might differ between model components."
     module purge
@@ -8,4 +8,4 @@ else
     module load intel-cc/17.0.1.132
     module load netcdf
     module load openmpi/1.10.2
-endif
+fi

--- a/util/make_dir/config.nci
+++ b/util/make_dir/config.nci
@@ -1,8 +1,8 @@
-if [ -f ../../modules.nci ]; then
-    echo "Loading common modules via modules.nci"
-    source ../../modules.nci
+if [ -f ../../environs.access-om2.nci ]; then
+    echo "Loading common modules via environs.access-om2.nci"
+    source ../../environs.access-om2.nci
 else
-    echo "WARNING: modules.nci not found. Module versions might differ between model components."
+    echo "WARNING: environs.access-om2.nci not found. Module versions might differ between model components."
     module purge
     module load intel-fc/17.0.1.132
     module load intel-cc/17.0.1.132


### PR DESCRIPTION
As discussed here: 
https://arccss.slack.com/archives/C6PP0GU9Y/p1516678999000106
but `modules.nci` is now called `environs.access-om2.nci`
and specifies `openmpi/1.10.2`, not `openmpi/3.0.0`

There are related pull requests for the other model components.