### PR TITLE
Created default target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ nci:
 	echo "include $(shell pwd)/util/make_dir/make.nci" > util/make_dir/make.inc
 	source ./util/make_dir/config.nci && cd util/make_dir && make -j 4 -f TopMakefileOasis3 
 
-ubuntu:
-	echo "include $(shell pwd)/util/make_dir/make.ubuntu" > util/make_dir/make.inc
+# This rule matches any target. To compile for an architecture (TARGETNAME) ensure 
+# a file called make.TARGETNAME exists in in util/make_dir 
+% ::
+	echo "include $(shell pwd)/util/make_dir/make.$@" > util/make_dir/make.inc
 	cd util/make_dir && make -j 4 -f TopMakefileOasis3 


### PR DESCRIPTION
Created default target so any supported make config can be called with the Makefile

For example, the travis-ci tests use the `ubuntu` target like so:

```
make ubuntu
```

The explicit `ubuntu` target has been removed, but the test still works. The `nci` target remains as it also sources an environment file. Arguably this may be redundant. It may be better to just rely on the default environment now rather than having to keep multiple environment files consistent.