### PR TITLE
use netcdf/4.7.4 to match what CICE uses in ACCESS-OM2

### DIFF
--- a/util/make_dir/config.gadi
+++ b/util/make_dir/config.gadi
@@ -1,4 +1,4 @@
 module purge
 module load intel-compiler/2019.5.281
-module load netcdf/4.7.1
+module load netcdf/4.7.4
 module load openmpi/4.0.2


### PR DESCRIPTION
CICE now uses netcdf/4.7.4p for PIO in access-om2 so it's probably best to match that here (with the serial version).